### PR TITLE
Trim read bytes from buffer while appending

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -171,7 +171,8 @@ doRead:
 		return nil, err
 	}
 
-	d.buf = append(d.buf, buf[:n]...)
+	d.buf = append(d.buf[d.off:], buf[:n]...)
+	d.off = 0
 
 	d.mu.Unlock()
 


### PR DESCRIPTION
Not sure it's the best place, but anyway we have to trim buffer periodically to prevent memory leaking.
